### PR TITLE
Update xliff-example1-0.9.3.json to show whitespace

### DIFF
--- a/JLIFF-schema-draft/jliff-example1-0.9.3.json
+++ b/JLIFF-schema-draft/jliff-example1-0.9.3.json
@@ -16,12 +16,12 @@
                     "canResegment": false,
                     "source": [
                         { "id": "c1", "kind": "ph", "dataRef": "d1" },
-                        { "text": "aaa" },
+                        { "text": " aaa " },
                         { "id": "c2", "kind": "pc", "dataRefStart": "d2", "dataRefEnd": "d3", "text": "text" }
                     ],
                     "target": [
                         { "id": "c1", "kind": "ph", "dataRef": "d1" },
-                        { "text": "AAA" },
+                        { "text": " AAA " },
                         { "id": "c2", "kind": "pc", "dataRefStart": "d2", "dataRefEnd": "d3", "text": "TEXT" }
                     ]
                 },


### PR DESCRIPTION
The Xliff 2.0 example [here](https://github.com/oasis-tcs/xliff-omos-jliff/blob/master/JLIFF-schema-draft/xliff-example1.xml#L11) shows whitespace around the source and target text elements aaa and AAA that are not present in the Jliff draft example. Whitespace in xml is a particular pain point for some serializers (such as .NET) so it would be good to show how the spaces are represented in Jliff.

![image](https://cloud.githubusercontent.com/assets/5757382/24103797/69317a74-0d4e-11e7-9041-b6254b9055e7.png)
